### PR TITLE
ci: use newer versions of things for speed

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -8,11 +8,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup-go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.23
           cache: true
           cache-dependency-path: go.sum
       - name: build
@@ -22,9 +22,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup-go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.23
           cache: true

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -5,16 +5,15 @@ on:
       - main
   pull_request:
 jobs:
-  build:
+  nix-devshell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
+    - uses: actions/checkout@v4
+    - name: Install Nix
+      uses: cachix/install-nix-action@v30
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - run: nix flake check
-    - run: nix develop --command which go # flakes
-    - run: nix-shell --run 'which go' # standard
     - run: nix develop --command nixpkgs-fmt --check *.nix
+    - run: nix flake check


### PR DESCRIPTION
- Updates the nix check to lint `*.nix` files and check that the devshell works
- Updates the golang steps to use better caching and a newer golangci-lint, to match the devshell
- Speeds everything up dramatically as a result: 
![image](https://github.com/user-attachments/assets/f4961d03-50a5-427b-9b89-d76e3e3c3924)
