### PR TITLE
maint: fix CI, upgrade devshell

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -30,7 +30,7 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v6.5.0
         with:
           install-mode: "binary"
           version: v1.64.5 # matches `golangci-lint version` in nix devshell

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24 # matches `go version` in nix devshell
           cache: true
           cache-dependency-path: go.sum
       - name: build
@@ -26,11 +26,12 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24 # matches `go version` in nix devshell
           cache: true
           cache-dependency-path: go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           install-mode: "binary"
-          version: v1.61.0
+          version: v1.64.5 # matches `golangci-lint version` in nix devshell
+          verify: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,7 +14,6 @@ linters-settings:
     default-signifies-exhaustive: true
   nolintlint:
     allow-unused: false
-    allow-leading-space: false
     allow-no-explanation:
       - gochecknoglobals
       - gochecknoinits

--- a/Justfile
+++ b/Justfile
@@ -8,14 +8,23 @@
 set positional-arguments
 
 # print all available commands by default
-default:
-  just --list
+help:
+  @just --list
 
 # run the test suite
 test *args='./...':
   go test "$@"
 
-# lint the entire codebase
+# lint go and nix
 lint *args:
+  @just lint-go "$@"
+  @just lint-nix
+
+# lint golang
+lint-go *args:
+  golangci-lint config verify --config .golangci.yaml
   golangci-lint run --fix --config .golangci.yaml "$@"
+
+# lint nix
+lint-nix:
   find . -name '*.nix' | xargs nixpkgs-fmt

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1739740471,
+        "narHash": "sha256-5QO5/GdwYcOkAlXl579JefJ0IaUsTrQfirVbLRCmZFc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "888ab7d2844c0578ef8c33b2b591f6c531292cb1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
                 # golang
                 delve
                 go-outline
-                go
+                go_1_24
                 golangci-lint
                 gopkgs
                 gopls


### PR DESCRIPTION
(All due to golangci-lint shenanigans, hate that project so much.)

- golangci-lint-action v6.5.0 verifies the config and fails on any errors, which...
- revealed that [as of golangci-lint v1.61.0](https://golangci-lint.run/product/changelog/#v1610) the nolintlint `allow-leading-space` option had been removed

This PR addresses the issue by:

- upgrading the nix devshell to golangci-lint v1.64.5 (and go v1.24.0)
- updating `just lint` to run `golangci-lint config verify`
- pinning the `golangci-lint-action` workflow to v6.5.0, and `golangci-lint` to v1.64.5, to prevent further surprise breaking changes
- removing the unsupported `allow-leading-space` option from the golangci-lint config file
- updating the golang workflows to use go v1.24

