### PR TITLE
fix(check): correct failure messages for NoError and NotNil

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -123,7 +123,7 @@ func NoError(t common.T, err error) bool {
 	if err == nil {
 		return true
 	}
-	t.Error("expected <nil> error, received %v", err)
+	t.Error("expected <nil> error, received", err)
 	return false
 }
 
@@ -193,7 +193,7 @@ func NotNil(t common.T, v any) bool {
 	if !isNil(v) {
 		return true
 	}
-	t.Error("expected non-<nil> value, received <nil>: %v", v)
+	t.Error("expected non-<nil> value, received <nil>")
 	return false
 }
 


### PR DESCRIPTION
The failure message for `check.NoError` was using a format specifier `%v` with `t.Error`. `t.Error` and its related functions behave like `fmt.Println`, not `fmt.Printf`, which caused the `%v` to be printed literally as part of the error string. This change corrects the call to pass the error as a separate argument.

The failure message for `check.NotNil` was also trying to print the value, which is redundant since the value is known to be `<nil>` when the check fails. The message has been simplified to be more concise.