### PR TITLE
nit: use %+v consistently for formatting

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -44,7 +44,7 @@ func Equal[Type any](t common.T, want Type, got Type, opts ...gocmp.Option) bool
 	if diff == "" {
 		return true
 	}
-	t.Error(fmt.Sprintf("expected want == got\n--- want\n+++ got\n%s", diff))
+	t.Error(fmt.Sprintf("expected want == got\n--- want\n+++ got\n%+v", diff))
 	return false
 }
 
@@ -71,7 +71,7 @@ func LessThan[Type cmp.Ordered](t common.T, small Type, big Type) bool {
 	if small < big {
 		return true
 	}
-	t.Error(fmt.Sprintf("expected %v < %v", small, big))
+	t.Error(fmt.Sprintf("expected %+v < %+v", small, big))
 	return false
 }
 
@@ -81,7 +81,7 @@ func LessThanOrEqual[Type cmp.Ordered](t common.T, small Type, big Type) bool {
 	if small <= big {
 		return true
 	}
-	t.Error(fmt.Sprintf("expected %v <= %v", small, big))
+	t.Error(fmt.Sprintf("expected %+v <= %+v", small, big))
 	return false
 }
 
@@ -91,7 +91,7 @@ func GreaterThan[Type cmp.Ordered](t common.T, big Type, small Type) bool {
 	if big > small {
 		return true
 	}
-	t.Error(fmt.Sprintf("expected %v > %v", big, small))
+	t.Error(fmt.Sprintf("expected %+v > %+v", big, small))
 	return false
 }
 
@@ -101,7 +101,7 @@ func GreaterThanOrEqual[Type cmp.Ordered](t common.T, big Type, small Type) bool
 	if big >= small {
 		return true
 	}
-	t.Error(fmt.Sprintf("expected %v >= %v", big, small))
+	t.Error(fmt.Sprintf("expected %+v >= %+v", big, small))
 	return false
 }
 
@@ -111,7 +111,7 @@ func Error(t common.T, err error) bool {
 	if err != nil {
 		return true
 	}
-	t.Error("expected error, received <nil>")
+	t.Error(fmt.Sprintf("expected non-<nil> error, received %+v", err))
 	return false
 }
 
@@ -123,7 +123,7 @@ func NoError(t common.T, err error) bool {
 	if err == nil {
 		return true
 	}
-	t.Error("expected <nil> error, received", err)
+	t.Error(fmt.Sprintf("expected <nil> error, received %+v", err))
 	return false
 }
 
@@ -171,7 +171,7 @@ func Nil(t common.T, v any) bool {
 	if isNil(v) {
 		return true
 	}
-	t.Error(fmt.Sprintf("expected <nil>, received %v", v))
+	t.Error(fmt.Sprintf("expected <nil>, received %+v", v))
 	return false
 }
 
@@ -193,7 +193,7 @@ func NotNil(t common.T, v any) bool {
 	if !isNil(v) {
 		return true
 	}
-	t.Error("expected non-<nil> value, received <nil>")
+	t.Error(fmt.Sprintf("expected non-<nil> value, received %+v", v))
 	return false
 }
 

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -818,3 +818,27 @@ func TestNotNil(t *testing.T) {
 		check.False(t, mt.FailedNow())
 	})
 }
+
+func TestFailureMessages(t *testing.T) {
+	t.Skipf("remove this skip line to show the failure message of all checks")
+	check.False(t, true)
+	check.True(t, false)
+	check.NotEqual(t, []string{"hello"}, []string{"hello"})
+	check.Equal(t,
+		map[string]int{"hello": 1},
+		map[string]int{"goodbye": 2},
+	)
+	check.GreaterThan(t, 1, 4)
+	check.GreaterThanOrEqual(t, 4, 4)
+	check.LessThan(t, 8, 6)
+	check.LessThanOrEqual(t, 6, 6)
+	check.NoError(t, fmt.Errorf("oh no"))
+	check.Error(t, nil)
+	check.NotIn(t, 4, []int{2, 3, 4, 5})
+	check.In(t, "hello", []string{"goodbye", "world"})
+
+	var nilm map[string]string
+	check.NotNil(t, nilm)
+	nilm = map[string]string{"hello": "world"}
+	check.Nil(t, nilm)
+}

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -820,6 +820,7 @@ func TestNotNil(t *testing.T) {
 }
 
 func TestFailureMessages(t *testing.T) {
+	t.Parallel()
 	t.Skipf("remove this skip line to show the failure message of all checks")
 	check.False(t, true)
 	check.True(t, false)


### PR DESCRIPTION
Followup to https://github.com/peterldowns/testy/pull/9, this PR makes it so that all `t.Error()` calls use `fmt.Sprintf()` with `%+v` to format values. This prints them in their default representation, with struct field names if the value is a struct, [as documented in the fmt package](https://pkg.go.dev/fmt#hdr-Printing).

This is one of those weird little nitpicks I want to do to keep things "consistent" it's not any more right or wrong than before.

## Testing

I added a new test that skips itself, but when un-skipped, prints all the failure messages of the different checks. Running this test shows that the messages fixed by #9 still print correctly, as do all other messages:

```
--- FAIL: TestFailureMessages (0.00s)
    /Users/pd/code/testy/check/check_test.go:824: expected false
    /Users/pd/code/testy/check/check_test.go:825: expected true
    /Users/pd/code/testy/check/check_test.go:826: expected want != got
        want: [hello]
         got: [hello]
    /Users/pd/code/testy/check/check_test.go:827: expected want == got
        --- want
        +++ got
          map[string]int{
        + 	"goodbye": 2,
        - 	"hello":   1,
          }
        
    /Users/pd/code/testy/check/check_test.go:831: expected 1 > 4
    /Users/pd/code/testy/check/check_test.go:833: expected 8 < 6
    /Users/pd/code/testy/check/check_test.go:835: expected <nil> error, received oh no
    /Users/pd/code/testy/check/check_test.go:836: expected non-<nil> error, received <nil>
    /Users/pd/code/testy/check/check_test.go:837: expected slice to not contain element
        element: 4
          found: 4
    /Users/pd/code/testy/check/check_test.go:838: expected slice to contain element:
        element: hello
        
    /Users/pd/code/testy/check/check_test.go:841: expected non-<nil> value, received map[]
    /Users/pd/code/testy/check/check_test.go:843: expected <nil>, received map[hello:world]
FAIL
```